### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,4 +1,6 @@
 name: Lint PR Code
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,6 +3,10 @@
 
 name: Publish to NPM
 
+permissions:
+  contents: read
+  actions: write
+
 on:
   release:
     types: [created]
@@ -21,9 +25,6 @@ jobs:
   publish-npm:
     # needs: build
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      actions: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -21,6 +21,9 @@ jobs:
   publish-npm:
     # needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Potential fix for [https://github.com/haruyukitanuki/kumoha-react/security/code-scanning/2](https://github.com/haruyukitanuki/kumoha-react/security/code-scanning/2)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the minimal permissions required. Since this is a linting workflow that only reads the repository's code, the `contents: read` permission is sufficient. This change ensures that the workflow does not inadvertently gain unnecessary write permissions.

The `permissions` block should be added immediately after the `name` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
